### PR TITLE
Added type check for delay argument

### DIFF
--- a/lib/dtimer.js
+++ b/lib/dtimer.js
@@ -213,6 +213,10 @@ DTimer.prototype.post = function (ev, delay, cb) {
     var self = this;
     var evId;
 
+    if (typeof delay !== 'number') {
+        throw new Error('delay argument must be of type number');
+    }
+
     // Copy event.
     ev = JSON.parse(JSON.stringify(ev));
 
@@ -356,6 +360,10 @@ DTimer.prototype.confirm = function (evId, cb) {
 
 DTimer.prototype.changeDelay = function (evId, delay, cb) {
     var self = this;
+
+    if (typeof delay !== 'number') {
+        throw new Error('delay argument must be of type number');
+    }
 
     return this._redisTime()
     .then(function (now) {

--- a/test/ApiTests.js
+++ b/test/ApiTests.js
@@ -215,4 +215,34 @@ describe('ApiTests', function () {
             dt.post({ id: 'should throw', maxRetries: true /*bad*/ }, 1000, function () {});
         }, Error);
     });
+
+    it('Attempts to post with delay of type string should throw', function () {
+        sandbox.stub(require('lured'), 'create', function () {
+            return {
+                on: function () {},
+                load: function (cb) { process.nextTick(cb); },
+                state: 3
+            };
+        });
+        var pub = redis.createClient();
+        var dt = new DTimer('me', pub, null);
+        assert.throws(function () {
+            dt.post({ id: 'should throw', maxRetries: 5 }, '1000' /*bad*/, function () {});
+        }, Error);
+    });
+
+    it('Attempts to changeDelay with delay of type string should throw', function () {
+        sandbox.stub(require('lured'), 'create', function () {
+            return {
+                on: function () {},
+                load: function (cb) { process.nextTick(cb); },
+                state: 3
+            };
+        });
+        var pub = redis.createClient();
+        var dt = new DTimer('me', pub, null);
+        assert.throws(function () {
+            dt.changeDelay({ id: 'should throw', maxRetries: 5 }, '1000' /*bad*/, function () {});
+        }, Error);
+    });
 });


### PR DESCRIPTION
If you enter the number as a string it can be a pain to find the error in the code. So I added a type check for the delay argument.

affected functions: changeDelay and post
delay has to be of type number