### PR TITLE
Update debug dependency to avoid usage of package ms < 0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "bluebird": "^3.1.1",
-    "debug": "~1.0.4",
+    "debug": "~2.3.0",
     "lured": "~0.0.2",
     "redis": "~0.12.1",
     "underscore": "~1.6.0",


### PR DESCRIPTION
ms is vulnerable to regular expression denial of service (ReDoS) when extremely long version strings are parsed.
This is fixed with versions of ms > 0.7. The newer versions of debug use a version of ms > 0.7