### PR TITLE
Post a timer without overwrite

### DIFF
--- a/lib/dtimer.js
+++ b/lib/dtimer.js
@@ -209,12 +209,19 @@ DTimer.prototype.leave = function (cb) {
     .nodeify(cb);
 };
 
-DTimer.prototype.post = function (ev, delay, cb) {
+DTimer.prototype.post = function (ev, delay, overwrite, cb) {
     var self = this;
     var evId;
 
     if (typeof delay !== 'number') {
         throw new Error('delay argument must be of type number');
+    }
+    if (typeof overwrite === 'function') {
+        cb = overwrite;
+        overwrite = undefined;
+    }
+    if (overwrite === undefined) {
+        overwrite = true;
     }
 
     // Copy event.
@@ -245,9 +252,14 @@ DTimer.prototype.post = function (ev, delay, cb) {
 
     return this._redisTime()
     .then(function (now) {
-        return self._pub.multi()
-        .zadd(self._keys.ei, now+delay, evId)
-        .hset(self._keys.ed, evId, msg)
+        var zaddArgs = [ self._keys.ei, now+delay, evId ];
+        if (!overwrite) {
+            zaddArgs.unshift('NX');
+        }
+        var multi = self._pub.multi()
+        return multi
+        .zadd.apply(multi, zaddArgs)
+        [overwrite ? 'hset' : 'hsetnx'](self._keys.ed, evId, msg)
         .evalsha(
             scripts.update.sha,
             5,


### PR DESCRIPTION
This adds support to the `.post()` method to only post the timer if it
doesn't already exist.  This is useful for implementing application
logic where the timer must fire after `delay` milliseconds, or sooner if
the timer was already set (the current behaviour is to always overwrite
and extend the timer).  I've added a new parameter, but maintained
backwards compatibility.

I'm using this in my app because I needed it.  I don't have any tests,
but thought you might like to consider it anyway.