### PR TITLE
add 'ready' event

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ upcoming([option] [, cb]) => {Promise}
 
 ### Event types
 
+#### Event: 'ready' - Emitted when the module is ready to process events.
+
 #### Event: 'event' - Emitted when an event is received.
 The handler will be called with the following argument:
 

--- a/lib/dtimer.js
+++ b/lib/dtimer.js
@@ -81,6 +81,7 @@ function DTimer(id, pub, sub, option) {
             return;
         }
         debug(self._id+': lua loading successful');
+        self.emit('ready');
     });
     this._maxEvents = this._option.maxEvents;
 

--- a/test/ApiTests.js
+++ b/test/ApiTests.js
@@ -104,6 +104,14 @@ describe('ApiTests', function () {
         });
     });
 
+    it('emits ready after redis is setup successfully', function (done) {
+        var pub = redis.createClient();
+        var dt = new DTimer('me', pub, null);
+        dt.on('ready', function () {
+            done();
+        });
+    });
+
     it('Detect malformed message on subscribe', function (done) {
         sandbox.stub(require('lured'), 'create', function () {
             return {


### PR DESCRIPTION
`ready` event is emitted after lua scripts are successfully loaded
#19 